### PR TITLE
#6313 handle out-of-order scope closure

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
@@ -74,6 +74,15 @@ public interface ObservationRegistry {
     void setCurrentObservationScope(Observation.@Nullable Scope current);
 
     /**
+     * Sets the observation scope as current only if the candidate is present in the
+     * registry.
+     * @param candidate observation scope
+     */
+    default void setCurrentObservationScopeIfExists(Observation.@Nullable Scope candidate) {
+        setCurrentObservationScope(candidate);
+    }
+
+    /**
      * Configuration options for this registry.
      * @return observation configuration
      */

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -313,7 +313,10 @@ class SimpleObservation implements Observation {
             else {
                 log.trace("NoOp observation used with SimpleScope");
             }
-            this.registry.setCurrentObservationScope(previousObservationScope);
+            // DB connections might be closed out of order, so only set the previous scope
+            // as current if it has not been already closed (by checking if it still
+            // exists in the registry).
+            this.registry.setCurrentObservationScopeIfExists(previousObservationScope);
         }
 
         private @Nullable SimpleScope getLastScope(SimpleScope simpleScope) {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservationRegistry.java
@@ -51,6 +51,23 @@ class SimpleObservationRegistry implements ObservationRegistry {
     }
 
     @Override
+    public void setCurrentObservationScopeIfExists(Observation.@Nullable Scope candidate) {
+        if (candidate == null) {
+            setCurrentObservationScope(null);
+        }
+        else {
+            Observation.Scope scope = localObservationScope.get();
+            while (scope != null) {
+                if (scope.equals(candidate)) {
+                    setCurrentObservationScope(candidate);
+                    break;
+                }
+                scope = scope.getPreviousObservationScope();
+            }
+        }
+    }
+
+    @Override
     public ObservationConfig observationConfig() {
         return this.observationConfig;
     }


### PR DESCRIPTION
This is a naive attempt at handling DB connection closing that might happen out of order. In SimpleObservation#close() only set the previous scope as current if it has not already been closed (by checking if it still exists in the registry).